### PR TITLE
Improve the scripts

### DIFF
--- a/draw-all.sh
+++ b/draw-all.sh
@@ -21,11 +21,11 @@ if [ ! -f $MAIN/bob.log ]; then
 fi
 
 if [ ! -f $MAIN/start ]; then
-  grep "DEBUG.*validate_transaction_blocking" $MAIN/alice.log | head -n 1 | cut -f2 -d' ' | cut -f1 -d'.' > $MAIN/start
+  grep "TRACE.*validate_transaction_blocking" $MAIN/alice.log | head -n 1 | cut -f1,2 -d' ' | cut -f1 -d'.' > $MAIN/start
 fi
 
 if [ ! -f $MAIN/end ]; then
-  grep "DEBUG.*validate_transaction_blocking" $MAIN/alice.log | tail -n 1 | cut -f2 -d' ' | cut -f1 -d'.' > $MAIN/end
+  grep "TRACE.*validate_transaction_blocking" $MAIN/alice.log | tail -n 1 | cut -f1,2 -d' ' | cut -f1 -d'.' > $MAIN/end
 fi
 
 

--- a/parse-log.py
+++ b/parse-log.py
@@ -123,7 +123,7 @@ def main():
         },
         {
             "type": "txpool_maintain",
-            "regex": "(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}(?:\.\d{3})?).*maintain txs=\((\d+), (\d+)\) a=(\d+) i=(\d+) views=\[.*\] event=(NewBlock|NewBestBlock|Finalized) {.*} duration=(\d+\.\d+)([µms]+)",
+            "regex": r'(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}(?:\.\d{3})?).*maintain txs=\((\d+), (\d+)\) a=(\d+) i=(\d+) views=\[.*\] event=(NewBlock|NewBestBlock|Finalized) {.*} duration=(\d+\.\d+)([µms]+)',
             "guard": "maintain txs=",
             "column_names": ["date", "time", "unwatched_txs", "watched_txs", "active_views_count", "inactive_views_count", "event", "duration"],
             "extract_data": lambda match: (


### PR DESCRIPTION
- In my case `validate_transaction_blocking` is shown with `TRACE` level, and it looks like for small intervals we need to provide the hour too? otherwise `start` and `end` can not be used for plots.
- I got a warning with python3.12 regarding regex `\d` and not using raw strings